### PR TITLE
use LI2 instead of LDI, get address of devices

### DIFF
--- a/custom_components/ave_dominaplus/climate.py
+++ b/custom_components/ave_dominaplus/climate.py
@@ -115,6 +115,7 @@ def update_thermostat(
     command: AveMapCommand | None = None,
     properties: AveThermostatProperties | None = None,
     ave_device_id: int | None = None,
+    address_dec: int | None = None,
 ) -> None:
     """Update thermostat from WS records."""
     if properties is not None and ave_device_id is not None:
@@ -124,6 +125,7 @@ def update_thermostat(
             family=AVE_FAMILY_THERMOSTAT,
             ave_device_id=properties.device_id,
             properties=properties,
+            address_dec=address_dec,
         )
     if command is not None:
         # Updates from WTS that uses command ids as identifiers
@@ -135,6 +137,7 @@ def update_thermostat(
                     ave_device_id=command.device_id,
                     property_name="temperature",
                     property_value=int(parameters[2]) / 10,
+                    address_dec=address_dec,
                 )
             case "TL":
                 _update_thermostat(
@@ -143,6 +146,7 @@ def update_thermostat(
                     ave_device_id=command.device_id,
                     property_name="fan_level",
                     property_value=int(parameters[2]),
+                    address_dec=address_dec,
                 )
             case "TLO":
                 _update_thermostat(
@@ -151,6 +155,7 @@ def update_thermostat(
                     ave_device_id=command.device_id,
                     property_name="local_off",
                     property_value=(1 if int(parameters[2]) == 0 else 0),
+                    address_dec=address_dec,
                 )
             case "TO":
                 _update_thermostat(
@@ -159,6 +164,7 @@ def update_thermostat(
                     ave_device_id=command.device_id,
                     property_name="offset",
                     property_value=int(parameters[2]),
+                    address_dec=address_dec,
                 )
             case "TS":
                 _update_thermostat(
@@ -167,6 +173,7 @@ def update_thermostat(
                     ave_device_id=command.device_id,
                     property_name="season",
                     property_value=parameters[2],
+                    address_dec=address_dec,
                 )
     elif parameters[0] == "WT":
         match parameters[1]:
@@ -177,6 +184,7 @@ def update_thermostat(
                     ave_device_id=int(parameters[2]),
                     property_name="offset",
                     property_value=int(parameters[3]) / 10,
+                    address_dec=address_dec,
                 )
             case "S":
                 _update_thermostat(
@@ -185,6 +193,7 @@ def update_thermostat(
                     ave_device_id=int(parameters[2]),
                     property_name="season",
                     property_value=parameters[3],
+                    address_dec=address_dec,
                 )
             case "T":
                 _update_thermostat(
@@ -193,6 +202,7 @@ def update_thermostat(
                     ave_device_id=int(parameters[2]),
                     property_name="temperature",
                     property_value=int(parameters[3]) / 10,
+                    address_dec=address_dec,
                 )
             case "L":
                 _update_thermostat(
@@ -201,6 +211,7 @@ def update_thermostat(
                     ave_device_id=int(parameters[2]),
                     property_name="fan_level",
                     property_value=int(parameters[3]),
+                    address_dec=address_dec,
                 )
             case "Z":
                 _update_thermostat(
@@ -209,6 +220,7 @@ def update_thermostat(
                     ave_device_id=int(parameters[2]),
                     property_name="local_off",
                     property_value=int(parameters[3]),
+                    address_dec=address_dec,
                 )
     elif parameters[0] == "TM":
         _update_thermostat(
@@ -217,6 +229,7 @@ def update_thermostat(
             ave_device_id=int(parameters[1]),
             property_name="mode",
             property_value=parameters[2],
+            address_dec=address_dec,
         )
     elif parameters[0] == "TW":
         _update_thermostat(
@@ -225,6 +238,7 @@ def update_thermostat(
             ave_device_id=int(parameters[1]),
             property_name="window_state",
             property_value=parameters[2],
+            address_dec=address_dec,
         )
     elif parameters[0] == "TP":
         _update_thermostat(
@@ -233,6 +247,7 @@ def update_thermostat(
             ave_device_id=int(parameters[1]),
             property_name="set_point",
             property_value=int(parameters[2]) / 10,
+            address_dec=address_dec,
         )
 
 
@@ -243,6 +258,7 @@ def _update_thermostat(
     properties: AveThermostatProperties | None = None,
     property_name: str | None = None,
     property_value: Any = None,
+    address_dec: int | None = None,
 ) -> None:
     """Create or update thermostat based on incoming data from webserver."""
 
@@ -263,6 +279,8 @@ def _update_thermostat(
                     thermostat.set_name(properties.device_name)
         elif property_name is not None and property_value is not None:
             thermostat.update_specific_property(property_name, property_value)
+        if address_dec is not None:
+            thermostat.set_address_dec(address_dec)
     else:
         if properties is None:
             _LOGGER.debug(
@@ -288,6 +306,7 @@ def _update_thermostat(
             ave_properties=properties,
             webserver=server,
             name=entity_name,
+            address_dec=address_dec,
         )
 
         _LOGGER.info("Creating new thermostat entity %s", entity_name)
@@ -346,6 +365,7 @@ class AveThermostat(ClimateEntity):
         ave_properties: AveThermostatProperties,
         webserver: AveWebServer,
         name: str | None = None,
+        address_dec: int | None = None,
     ) -> None:
         """Initialize the thermostat sensor."""
         self._unique_id = unique_id
@@ -362,6 +382,8 @@ class AveThermostat(ClimateEntity):
         else:
             self._name = ave_properties.device_name
             self.ave_name = ave_properties.device_name
+
+        self._address_dec = address_dec
 
         self._selected_schedule = None
         self.update_all_properties(ave_properties, first_update=True)
@@ -598,6 +620,10 @@ class AveThermostat(ClimateEntity):
             "AVE webserver MAC": self._webserver.mac_address
             if self._webserver
             else None,
+            "AVE address_dec": self._address_dec,
+            "AVE address_hex": format(self._address_dec & 0xFF, "02X")
+            if self._address_dec is not None
+            else "",
         }
 
     def update_ave_properties(self, properties: AveThermostatProperties) -> None:
@@ -616,6 +642,12 @@ class AveThermostat(ClimateEntity):
             return
         self._name = name
         self.async_write_ha_state()
+
+    def set_address_dec(self, address_dec: int | None) -> None:
+        """Set the address_dec attribute of the sensor."""
+        if address_dec is not None and self._address_dec != address_dec:
+            self._address_dec = address_dec
+            self.async_write_ha_state()
 
     def build_name(self) -> str:
         """Build the name of the sensor based on its family and device ID."""

--- a/custom_components/ave_dominaplus/sensor.py
+++ b/custom_components/ave_dominaplus/sensor.py
@@ -93,7 +93,12 @@ def set_sensor_uid(webserver: AveWebServer, family, ave_device_id) -> str:
 
 
 def update_th_offset(
-    server: AveWebServer, family, ave_device_id, offset_value, name=None
+    server: AveWebServer,
+    family,
+    ave_device_id,
+    offset_value,
+    name=None,
+    address_dec: int | None = None,
 ) -> None:
     """Update switch based on the family and device status."""
     if family == AVE_FAMILY_THERMOSTAT:
@@ -119,6 +124,8 @@ def update_th_offset(
         # Update the existing sensor's state
         number: ThermostatOffset = server.numbers[unique_id]
         number.update_value(offset_value)
+        if address_dec is not None:
+            number.set_address_dec(address_dec)
     else:
         # Create a new switch sensor
         entity_ave_name = None
@@ -133,6 +140,7 @@ def update_th_offset(
             name=None,
             ave_name=entity_ave_name,
             value=offset_value,
+            address_dec=address_dec,
         )
 
         _LOGGER.info("Creating new number entity %s", name)
@@ -178,6 +186,7 @@ class ThermostatOffset(SensorEntity):
         name=None,
         ave_name: str | None = None,
         value: float | None = None,
+        address_dec: int | None = None,
     ) -> None:
         """Initialize the thermostat offset."""
         self._unique_id = unique_id
@@ -186,6 +195,7 @@ class ThermostatOffset(SensorEntity):
         self._ave_name = ave_name
         self._webserver = webserver
         self.hass = self._webserver.hass
+        self._address_dec = address_dec
 
         if name is None:
             if webserver.settings.get_entity_names:
@@ -223,6 +233,10 @@ class ThermostatOffset(SensorEntity):
             "AVE webserver MAC": self._webserver.mac_address
             if self._webserver
             else None,
+            "AVE address_dec": self._address_dec,
+            "AVE address_hex": format(self._address_dec & 0xFF, "02X")
+            if self._address_dec is not None
+            else "",
         }
 
     def update_value(self, offset_value: float, first_update=False) -> None:
@@ -244,6 +258,12 @@ class ThermostatOffset(SensorEntity):
         """Set the AVE name of the sensor."""
         if name is not None:
             self._ave_name = name + " offset"
+            self.async_write_ha_state()
+
+    def set_address_dec(self, address_dec: int | None) -> None:
+        """Set the address_dec attribute of the sensor."""
+        if address_dec is not None and self._address_dec != address_dec:
+            self._address_dec = address_dec
             self.async_write_ha_state()
 
     def build_name(self) -> str:

--- a/custom_components/ave_dominaplus/switch.py
+++ b/custom_components/ave_dominaplus/switch.py
@@ -94,7 +94,12 @@ def set_sensor_uid(webserver: AveWebServer, family, ave_device_id) -> str:
 
 
 def update_switch(
-    server: AveWebServer, family, ave_device_id, device_status, name=None
+    server: AveWebServer,
+    family,
+    ave_device_id,
+    device_status,
+    name=None,
+    address_dec=None,
 ) -> None:
     """Update switch based on the family and device status."""
     if family == AVE_FAMILY_SWITCH:
@@ -121,6 +126,8 @@ def update_switch(
             switch.set_ave_name(name)
             if not check_name_changed(server.hass, unique_id):
                 switch.set_name(name)
+        if address_dec is not None:
+            switch.set_address_dec(address_dec)
     else:
         # Create a new switch sensor
         entity_name = None
@@ -137,6 +144,7 @@ def update_switch(
             webserver=server,
             name=entity_name,
             ave_name=entity_ave_name,
+            address_dec=address_dec,
         )
 
         _LOGGER.info("Creating new switch entity %s, unique_id %s", name, unique_id)
@@ -175,6 +183,7 @@ class LightSwitch(SwitchEntity):
         webserver: AveWebServer,
         name=None,
         ave_name: str | None = None,
+        address_dec: int | None = None,
     ) -> None:
         """Initialize the motion detection sensor."""
         self._unique_id = unique_id
@@ -183,6 +192,7 @@ class LightSwitch(SwitchEntity):
         self.family = family
         self._webserver = webserver
         self._ave_name = ave_name
+        self._address_dec = address_dec
         self.hass = self._webserver.hass
 
         if is_on is not None and is_on >= 0:
@@ -230,6 +240,10 @@ class LightSwitch(SwitchEntity):
             "AVE_family": self.family,
             "AVE_device_id": self.ave_device_id,
             "AVE_name": self._ave_name,
+            "AVE address_dec": self._address_dec,
+            "AVE address_hex": format(self._address_dec & 0xFF, "02X")
+            if self._address_dec is not None
+            else "",
             "AVE webserver MAC": self._webserver.mac_address
             if self._webserver
             else None,
@@ -255,6 +269,12 @@ class LightSwitch(SwitchEntity):
         """Set the AVE name of the sensor."""
         if name is not None:
             self._ave_name = name
+            self.async_write_ha_state()
+
+    def set_address_dec(self, address_dec: int | None) -> None:
+        """Set the address_dec attribute of the sensor."""
+        if address_dec is not None and self._address_dec != address_dec:
+            self._address_dec = address_dec
             self.async_write_ha_state()
 
     def build_name(self) -> str:

--- a/custom_components/ave_dominaplus/web_server.py
+++ b/custom_components/ave_dominaplus/web_server.py
@@ -220,7 +220,8 @@ class AveWebServer:
             return
 
         self._ldi_done.clear()
-        await self.send_ws_command("LDI")  # Get device list
+        # await self.send_ws_command("LDI")  # Get device list (legacy)
+        await self.send_ws_command("LI2")  # Get device list (with addresses)
         if not await self._wait_for_ldi():
             return
 
@@ -387,8 +388,8 @@ class AveWebServer:
             self.manage_gsf(parameters, records)
         elif command == "upd":
             self.manage_upd(parameters, records)
-        elif command == "ldi":
-            self.manage_ldi(parameters, records)
+        elif command in {"ldi", "li2"}:
+            self.manage_ldi_li2(parameters, records, command)
         elif command == "lm":
             self.manage_lm(parameters, records)
         elif command == "lmc":
@@ -610,25 +611,47 @@ class AveWebServer:
                 )
                 # send_mqtt_message(device_id, device_status)
 
-    def manage_ldi(self, parameters: list[Any], records: list[list[Any]]) -> None:
-        """Manage LDI List Devices commands received from the web server."""
+    def manage_ldi_li2(
+        self, parameters: list[Any], records: list[list[Any]], command: str
+    ) -> None:
+        """Manage LDI/LI2 List Devices commands received from the web server."""
         _LOGGER.debug(
-            "Parsing LDI (List Devices) command, parameters: %s | records: %s",
+            "Parsing %s (List Devices) command, parameters: %s | records: %s",
+            command,
             parameters,
             records,
         )
         self.raw_ldi = []
         for record in records:
-            device_id, device_name, device_type = (
+            device_id, device_name, device_type, address = (
                 int(record[0]),
                 str(record[1]),
                 int(record[2]),
+                record[3],
             )
+            # record[3] contains the decimal representation of the address
+            address_dec = None
+            address_hex = None
+            if command == "li2":
+                try:
+                    address_dec = int(str(address).strip())
+                except Exception:
+                    _LOGGER.debug(
+                        "Failed parsing address '%s'; leaving address_dec unset",
+                        address,
+                    )
+                    address_dec = None
+                # Store address as two-digit uppercase hex string when available
+                address_hex = (
+                    format(address_dec & 0xFF, "02X") if address_dec is not None else ""
+                )
             self.raw_ldi.append(
                 {
                     "device_id": device_id,
                     "device_name": device_name,
                     "device_type": device_type,
+                    "address_dec": address_dec,
+                    "address_hex": address_hex,
                 }
             )
             if device_name and device_name[0] == "$":
@@ -646,11 +669,17 @@ class AveWebServer:
                 # Keypad
                 pass
             elif device_type == AVE_FAMILY_SWITCH:
-                self.update_switch(self, AVE_FAMILY_SWITCH, device_id, -1, device_name)
+                self.update_switch(
+                    self, AVE_FAMILY_SWITCH, device_id, -1, device_name, address_dec
+                )
                 # Light
             elif device_type == AVE_FAMILY_THERMOSTAT:
                 # All thermostats
-                self.all_thermostats_raw[device_id] = device_name
+                self.all_thermostats_raw[device_id] = {
+                    "device_name": device_name,
+                    "address_dec": address_dec,
+                    "address_hex": address_hex,
+                }
             elif device_type == AVE_FAMILY_SCENARIO:
                 # Scenario
                 pass
@@ -703,7 +732,9 @@ class AveWebServer:
             f"thermostat_{thermostat_properties.device_id}"
         )
         if self.settings.get_entity_names:
-            thermostat_properties.device_name = self.all_thermostats_raw[device_id]
+            thermostat_properties.device_name = self.all_thermostats_raw[device_id][
+                "device_name"
+            ]
 
         self.update_thermostat(
             server=self,
@@ -712,6 +743,7 @@ class AveWebServer:
             command=None,
             properties=thermostat_properties,
             ave_device_id=device_id,
+            address_dec=self.all_thermostats_raw[device_id].get("address_dec"),
         )
         if thermostat_properties.offset is not None:
             self.update_th_offset(
@@ -720,6 +752,7 @@ class AveWebServer:
                 ave_device_id=device_id,
                 offset_value=thermostat_properties.offset,
                 name=thermostat_properties.device_name,
+                address_dec=self.all_thermostats_raw[device_id].get("address_dec"),
             )
 
     async def switch_turn_on(self, device_id: int) -> None:


### PR DESCRIPTION
Device discovery is now done using LI2 instead of LDI. #15 

Bus address of related device is now stored as an extra attribute of any entity this applies to.

To be tested: verify LI2 doesn't skip any esotic devices that is only provided by LDI