### PR TITLE
Feature: Translate Containers and Entity Names

### DIFF
--- a/custom_components/ave_dominaplus/binary_sensor.py
+++ b/custom_components/ave_dominaplus/binary_sensor.py
@@ -483,8 +483,10 @@ class ScenarioRunningBinarySensor(BinarySensorEntity):
             ave_name=ave_name,
         )
 
+        self._name = None
         if name is None:
-            self._name = self.build_name()
+            self._attr_translation_key = "scenario_running"
+            self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
         else:
             self._name = name
 

--- a/custom_components/ave_dominaplus/binary_sensor.py
+++ b/custom_components/ave_dominaplus/binary_sensor.py
@@ -351,10 +351,7 @@ class MotionBinarySensor(BinarySensorEntity):
         self._attr_family = family
         self._name = None
         if name is None:
-            if self.family == AVE_FAMILY_ANTITHEFT_AREA:
-                self._attr_translation_key = "antitheft_area"
-                self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
-            elif self.family == AVE_FAMILY_MOTION_SENSOR:
+            if self.family == AVE_FAMILY_MOTION_SENSOR:
                 self._attr_translation_key = "antitheft_sensor"
                 self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
             else:
@@ -444,7 +441,12 @@ class MotionBinarySensor(BinarySensorEntity):
 
     def build_name(self) -> str:
         """Build the name of the sensor based on its family and device ID."""
-        return f"Sensor {self.family} {self.ave_device_id}"
+        suffix = f"Sensor {self.family}"
+        if self.family == AVE_FAMILY_ANTITHEFT_AREA:
+            suffix = "Antitheft Area"
+        elif self.family == AVE_FAMILY_MOTION_SENSOR:
+            suffix = "Antitheft Sensor"
+        return f"{suffix} {self.ave_device_id}"
 
 
 class ScenarioRunningBinarySensor(BinarySensorEntity):

--- a/custom_components/ave_dominaplus/binary_sensor.py
+++ b/custom_components/ave_dominaplus/binary_sensor.py
@@ -349,18 +349,15 @@ class MotionBinarySensor(BinarySensorEntity):
         )
 
         self._attr_family = family
-        self._name = None
         if name is None:
             if self.family == AVE_FAMILY_MOTION_SENSOR:
-                self._attr_translation_key = "antitheft_sensor"
-                self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
+                self._attr_name = f"Sensor {self.ave_device_id}"
             elif self.family == AVE_FAMILY_ANTITHEFT_AREA:
-                self._attr_translation_key = "antitheft_area"
-                self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
+                self._attr_name = f"Area {self.ave_device_id}"
             else:
-                self._name = self.build_name()
+                self._attr_name = self.build_name()
         else:
-            self._name = name
+            self._attr_name = name
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to Home Assistant."""
@@ -376,11 +373,6 @@ class MotionBinarySensor(BinarySensorEntity):
     def unique_id(self) -> str:
         """Return the unique ID of the sensor."""
         return self._unique_id
-
-    @property
-    def name(self) -> str | None:
-        """Return the name of the sensor."""
-        return self._name
 
     @property
     def available(self) -> bool:
@@ -431,7 +423,7 @@ class MotionBinarySensor(BinarySensorEntity):
         """Set the name of the sensor."""
         if name is None:
             return
-        self._name = name
+        self._attr_name = name
         if self.hass:
             self.async_write_ha_state()
 
@@ -486,12 +478,10 @@ class ScenarioRunningBinarySensor(BinarySensorEntity):
             ave_name=ave_name,
         )
 
-        self._name = None
         if name is None:
             self._attr_translation_key = "scenario_running"
-            self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
         else:
-            self._name = name
+            self._attr_name = name
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to Home Assistant."""
@@ -507,11 +497,6 @@ class ScenarioRunningBinarySensor(BinarySensorEntity):
     def unique_id(self) -> str:
         """Return the unique ID of the sensor."""
         return self._unique_id
-
-    @property
-    def name(self) -> str | None:
-        """Return the name of the sensor."""
-        return self._name
 
     @property
     def available(self) -> bool:
@@ -561,7 +546,7 @@ class ScenarioRunningBinarySensor(BinarySensorEntity):
         """Set the name of the sensor."""
         if name is None:
             return
-        self._name = name
+        self._attr_name = name
         if self.hass:
             self.async_write_ha_state()
 

--- a/custom_components/ave_dominaplus/binary_sensor.py
+++ b/custom_components/ave_dominaplus/binary_sensor.py
@@ -353,7 +353,8 @@ class MotionBinarySensor(BinarySensorEntity):
         if name is None:
             if self.family == AVE_FAMILY_MOTION_SENSOR:
                 self._attr_translation_key = "antitheft_sensor"
-                self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
+            elif self.family == AVE_FAMILY_ANTITHEFT_AREA:
+                self._attr_translation_key = "antitheft_area"
             else:
                 self._name = self.build_name()
         else:

--- a/custom_components/ave_dominaplus/binary_sensor.py
+++ b/custom_components/ave_dominaplus/binary_sensor.py
@@ -353,8 +353,10 @@ class MotionBinarySensor(BinarySensorEntity):
         if name is None:
             if self.family == AVE_FAMILY_MOTION_SENSOR:
                 self._attr_translation_key = "antitheft_sensor"
+                self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
             elif self.family == AVE_FAMILY_ANTITHEFT_AREA:
                 self._attr_translation_key = "antitheft_area"
+                self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
             else:
                 self._name = self.build_name()
         else:

--- a/custom_components/ave_dominaplus/binary_sensor.py
+++ b/custom_components/ave_dominaplus/binary_sensor.py
@@ -172,7 +172,7 @@ def _parse_motion_uid(unique_id: str) -> tuple[int, int] | None:
 
 def _scenario_running_name(ave_name: str) -> str:
     """Build scenario running entity name from AVE native name."""
-    return f"{ave_name} Running"
+    return ave_name
 
 
 def update_binary_sensor(

--- a/custom_components/ave_dominaplus/binary_sensor.py
+++ b/custom_components/ave_dominaplus/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.dt import utcnow
 
 from .const import (
@@ -37,7 +37,7 @@ SCENARIO_RUNNING_UID_SUFFIX = "running"
 async def async_setup_entry(
     _hass: HomeAssistant | None,
     entry: ConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AVE dominaplus binary sensors.
 

--- a/custom_components/ave_dominaplus/binary_sensor.py
+++ b/custom_components/ave_dominaplus/binary_sensor.py
@@ -348,11 +348,19 @@ class MotionBinarySensor(BinarySensorEntity):
             webserver, family, ave_device_id
         )
 
+        self._attr_family = family
+        self._name = None
         if name is None:
-            self._name = self.build_name()
+            if self.family == AVE_FAMILY_ANTITHEFT_AREA:
+                self._attr_translation_key = "antitheft_area"
+                self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
+            elif self.family == AVE_FAMILY_MOTION_SENSOR:
+                self._attr_translation_key = "antitheft_sensor"
+                self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
+            else:
+                self._name = self.build_name()
         else:
             self._name = name
-        self._attr_family = family
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to Home Assistant."""
@@ -370,7 +378,7 @@ class MotionBinarySensor(BinarySensorEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the sensor."""
         return self._name
 
@@ -499,7 +507,7 @@ class ScenarioRunningBinarySensor(BinarySensorEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the sensor."""
         return self._name
 

--- a/custom_components/ave_dominaplus/binary_sensor.py
+++ b/custom_components/ave_dominaplus/binary_sensor.py
@@ -444,12 +444,7 @@ class MotionBinarySensor(BinarySensorEntity):
 
     def build_name(self) -> str:
         """Build the name of the sensor based on its family and device ID."""
-        suffix = f"Sensor {self.family}"
-        if self.family == AVE_FAMILY_ANTITHEFT_AREA:
-            suffix = "Antitheft Area"
-        elif self.family == AVE_FAMILY_MOTION_SENSOR:
-            suffix = "Antitheft Sensor"
-        return f"{suffix} {self.ave_device_id}"
+        return f"Sensor {self.family} {self.ave_device_id}"
 
 
 class ScenarioRunningBinarySensor(BinarySensorEntity):

--- a/custom_components/ave_dominaplus/button.py
+++ b/custom_components/ave_dominaplus/button.py
@@ -205,12 +205,10 @@ class ScenarioButton(ButtonEntity):
             ave_name=ave_name,
         )
 
-        self._name = None
         if name is None:
             self._attr_translation_key = "scenario_run"
-            self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
         else:
-            self._name = name
+            self._attr_name = name
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to Home Assistant."""
@@ -230,11 +228,6 @@ class ScenarioButton(ButtonEntity):
     def unique_id(self) -> str:
         """Return the unique ID of the entity."""
         return self._unique_id
-
-    @property
-    def name(self) -> str | None:
-        """Return the name of the entity."""
-        return self._name
 
     @property
     def available(self) -> bool:
@@ -260,7 +253,7 @@ class ScenarioButton(ButtonEntity):
         """Set entity name."""
         if name is None:
             return
-        self._name = name
+        self._attr_name = name
         self._write_state_or_defer()
 
     def set_ave_name(self, name: str | None) -> None:

--- a/custom_components/ave_dominaplus/button.py
+++ b/custom_components/ave_dominaplus/button.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ws_commands
 from .const import AVE_FAMILY_SCENARIO
@@ -28,7 +28,7 @@ SCENARIO_BUTTON_UID_SUFFIX = "button"
 async def async_setup_entry(
     _hass: HomeAssistant | None,
     entry: ConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AVE dominaplus scenario buttons."""
     webserver: AveWebServer = entry.runtime_data

--- a/custom_components/ave_dominaplus/button.py
+++ b/custom_components/ave_dominaplus/button.py
@@ -205,7 +205,12 @@ class ScenarioButton(ButtonEntity):
             ave_name=ave_name,
         )
 
-        self._name = self.build_name() if name is None else name
+        self._name = None
+        if name is None:
+            self._attr_translation_key = "scenario_run"
+            self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
+        else:
+            self._name = name
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to Home Assistant."""
@@ -227,7 +232,7 @@ class ScenarioButton(ButtonEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the entity."""
         return self._name
 

--- a/custom_components/ave_dominaplus/button.py
+++ b/custom_components/ave_dominaplus/button.py
@@ -105,7 +105,7 @@ def set_button_uid(server: AveWebServer, family: int, ave_device_id: int) -> str
 
 def _format_button_name(ave_name: str) -> str:
     """Return the entity name derived from AVE native scenario name."""
-    return f"{ave_name} Run"
+    return ave_name
 
 
 def update_button(

--- a/custom_components/ave_dominaplus/climate.py
+++ b/custom_components/ave_dominaplus/climate.py
@@ -19,7 +19,7 @@ from homeassistant.const import PRECISION_TENTHS, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ws_commands
 from .ave_map import AveMapCommand
@@ -42,7 +42,7 @@ PRESET_MANUAL = "Manual"
 async def async_setup_entry(
     _hass: HomeAssistant | None,
     entry: ConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AVE dominaplus thermostats.
 

--- a/custom_components/ave_dominaplus/climate.py
+++ b/custom_components/ave_dominaplus/climate.py
@@ -394,11 +394,11 @@ class AveThermostat(ClimateEntity):
         self.ave_properties: AveThermostatProperties = ave_properties
         self.ave_name = ""
         if name is not None:
-            self._name = name
+            self._attr_name = name
         elif ave_properties.device_name is None:
-            self._name = self.build_name()
+            self._attr_name = self.build_name()
         else:
-            self._name = ave_properties.device_name
+            self._attr_name = ave_properties.device_name
             self.ave_name = ave_properties.device_name
 
         self._address_dec = address_dec
@@ -633,11 +633,6 @@ class AveThermostat(ClimateEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str | None:
-        """Return the name of the sensor."""
-        return self._name
-
-    @property
     def available(self) -> bool:
         """Return if the backing webserver connection is available."""
         return self._webserver.connected
@@ -673,7 +668,7 @@ class AveThermostat(ClimateEntity):
         """Set the name of the sensor."""
         if name is None:
             return
-        self._name = name
+        self._attr_name = name
         self._sync_device_name(name)
         self.async_write_ha_state()
 

--- a/custom_components/ave_dominaplus/climate.py
+++ b/custom_components/ave_dominaplus/climate.py
@@ -633,7 +633,7 @@ class AveThermostat(ClimateEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the sensor."""
         return self._name
 

--- a/custom_components/ave_dominaplus/config_flow.py
+++ b/custom_components/ave_dominaplus/config_flow.py
@@ -9,6 +9,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
+
 try:
     from homeassistant.components.zeroconf import ZeroconfServiceInfo
 except ImportError:

--- a/custom_components/ave_dominaplus/config_flow.py
+++ b/custom_components/ave_dominaplus/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import format_mac
-from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+from homeassistant.components.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN
 from .web_server import AveWebServer

--- a/custom_components/ave_dominaplus/config_flow.py
+++ b/custom_components/ave_dominaplus/config_flow.py
@@ -9,11 +9,11 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
+from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import format_mac
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 
 from .const import DOMAIN
 from .web_server import AveWebServer

--- a/custom_components/ave_dominaplus/config_flow.py
+++ b/custom_components/ave_dominaplus/config_flow.py
@@ -9,7 +9,10 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
+try:
+    from homeassistant.components.zeroconf import ZeroconfServiceInfo
+except ImportError:
+    from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.exceptions import HomeAssistantError

--- a/custom_components/ave_dominaplus/cover.py
+++ b/custom_components/ave_dominaplus/cover.py
@@ -12,7 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ws_commands
 from .const import (
@@ -41,7 +41,7 @@ COVER_FAMILIES = (
 async def async_setup_entry(
     _hass: HomeAssistant | None,
     entry: ConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AVE dominaplus covers."""
     webserver: AveWebServer = entry.runtime_data

--- a/custom_components/ave_dominaplus/cover.py
+++ b/custom_components/ave_dominaplus/cover.py
@@ -277,7 +277,6 @@ class AveCover(CoverEntity):
 
         self._attr_device_class = CoverDeviceClass.SHUTTER
 
-        self._name = None
         if name is None:
             if self.family == AVE_FAMILY_SHUTTER_ROLLING:
                 self._attr_translation_key = "shutter"
@@ -287,9 +286,8 @@ class AveCover(CoverEntity):
                 self._attr_translation_key = "window"
             else:
                 self._attr_translation_key = "cover"
-            self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
         else:
-            self._name = name
+            self._attr_name = name
 
         self._position = 3
         if position is not None:
@@ -360,11 +358,6 @@ class AveCover(CoverEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str | None:
-        """Return the name of the entity."""
-        return self._name
-
-    @property
     def available(self) -> bool:
         """Return if the backing webserver connection is available."""
         return self._webserver.connected
@@ -426,7 +419,7 @@ class AveCover(CoverEntity):
         """Set the entity name."""
         if name is None:
             return
-        self._name = name
+        self._attr_name = name
         self._sync_device_info(name)
         self._write_state_or_defer()
 

--- a/custom_components/ave_dominaplus/cover.py
+++ b/custom_components/ave_dominaplus/cover.py
@@ -277,8 +277,17 @@ class AveCover(CoverEntity):
 
         self._attr_device_class = CoverDeviceClass.SHUTTER
 
+        self._name = None
         if name is None:
-            self._name = self.build_name()
+            if self.family == AVE_FAMILY_SHUTTER_ROLLING:
+                self._attr_translation_key = "shutter"
+            elif self.family == AVE_FAMILY_SHUTTER_SLIDING:
+                self._attr_translation_key = "blind"
+            elif self.family == AVE_FAMILY_SHUTTER_HUNG:
+                self._attr_translation_key = "window"
+            else:
+                self._attr_translation_key = "cover"
+            self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
         else:
             self._name = name
 
@@ -351,7 +360,7 @@ class AveCover(CoverEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the entity."""
         return self._name
 

--- a/custom_components/ave_dominaplus/device_info.py
+++ b/custom_components/ave_dominaplus/device_info.py
@@ -420,10 +420,11 @@ def sync_device_registry_name(
     if isinstance(via_identifier, tuple) and len(via_identifier) == 2:
         via_entry = device_registry.async_get_device(identifiers={via_identifier})
         current_via_device_id = getattr(device_entry, "via_device_id", None)
-        if via_entry is not None and via_entry.id not in {
-            device_entry.id,
-            current_via_device_id,
-        }:
+        if (
+            via_entry is not None  # noqa: PLR1714
+            and via_entry.id != device_entry.id
+            and current_via_device_id != via_entry.id
+        ):
             updates["via_device_id"] = via_entry.id
 
     if updates:

--- a/custom_components/ave_dominaplus/device_info.py
+++ b/custom_components/ave_dominaplus/device_info.py
@@ -84,12 +84,12 @@ def is_structural_parent_identifier(identifier: tuple[str, str]) -> bool:
 
 def _hub_identifier(server: AveWebServer) -> str:
     """Build a stable hub identifier for the device registry."""
+    if server.config_entry_id:
+        return server.config_entry_id
     if server.mac_address:
         return server.mac_address.lower()
     if server.config_entry_unique_id:
         return server.config_entry_unique_id.lower()
-    if server.config_entry_id:
-        return server.config_entry_id
     return server.settings.host
 
 

--- a/custom_components/ave_dominaplus/device_info.py
+++ b/custom_components/ave_dominaplus/device_info.py
@@ -254,10 +254,25 @@ def build_endpoint_device_info(
     Device identifiers include the hub identifier to avoid collisions across hubs.
     """
     group_key = _endpoint_group_key(family, ave_device_id)
-    endpoint_identifier = (
-        DOMAIN,
-        f"endpoint_{_hub_identifier(server)}_{group_key}",
-    )
+    if group_key == _GROUP_ANTITHEFT_SENSORS:
+        endpoint_identifier = (
+            DOMAIN,
+            f"endpoint_{_hub_identifier(server)}_{group_key}_{ave_device_id}",
+        )
+        translation_key = group_key
+        device_name = None
+    elif group_key == _GROUP_ANTITHEFT_AREAS:
+        endpoint_identifier = (
+            DOMAIN,
+            f"endpoint_{_hub_identifier(server)}_{group_key}_{ave_device_id}",
+        )
+        translation_key = group_key
+        device_name = None
+    else:
+        endpoint_identifier = (
+            DOMAIN,
+            f"endpoint_{_hub_identifier(server)}_{group_key}",
+        )
 
     via_device = _hub_device_identifier(server)
     if family in (AVE_FAMILY_ONOFFLIGHTS, AVE_FAMILY_DIMMER):
@@ -274,11 +289,7 @@ def build_endpoint_device_info(
         via_device = _scenarios_parent_device_identifier(server)
 
     device_name: str | None = _endpoint_name(family, ave_device_id, ave_name)
-    translation_key: str | None = None
-
-    if group_key in (_GROUP_ANTITHEFT_SENSORS, _GROUP_ANTITHEFT_AREAS):
-        translation_key = group_key
-        device_name = None
+    translation_key: str | None = translation_key
 
     return DeviceInfo(
         identifiers={endpoint_identifier},
@@ -286,6 +297,7 @@ def build_endpoint_device_info(
         model=_endpoint_model(family),
         name=device_name,
         translation_key=translation_key,
+        translation_placeholders={"id": str(ave_device_id)},
         via_device=via_device,
         configuration_url=f"http://{server.settings.host}",
     )

--- a/custom_components/ave_dominaplus/device_info.py
+++ b/custom_components/ave_dominaplus/device_info.py
@@ -236,7 +236,8 @@ def build_hub_device_info(server: AveWebServer) -> DeviceInfo:
         connections=connections,
         manufacturer="AVE",
         model="AVE dominaplus webserver",
-        name="Dominaplus Hub",
+        translation_key="hub",
+        name=None,
         configuration_url=f"http://{server.settings.host}",
     )
 
@@ -272,11 +273,19 @@ def build_endpoint_device_info(
     elif family == AVE_FAMILY_SCENARIO:
         via_device = _scenarios_parent_device_identifier(server)
 
+    device_name: str | None = _endpoint_name(family, ave_device_id, ave_name)
+    translation_key: str | None = None
+
+    if group_key in (_GROUP_ANTITHEFT_SENSORS, _GROUP_ANTITHEFT_AREAS):
+        translation_key = group_key
+        device_name = None
+
     return DeviceInfo(
         identifiers={endpoint_identifier},
         manufacturer="AVE",
         model=_endpoint_model(family),
-        name=_endpoint_name(family, ave_device_id, ave_name),
+        name=device_name,
+        translation_key=translation_key,
         via_device=via_device,
         configuration_url=f"http://{server.settings.host}",
     )
@@ -294,7 +303,8 @@ def ensure_lighting_parent_device(server: AveWebServer, config_entry_id: str) ->
             identifiers={_lighting_parent_device_identifier(server)},
             manufacturer="AVE",
             model=_GROUP_MODELS[_GROUP_LIGHTING],
-            name=_GROUP_NAMES[_GROUP_LIGHTING],
+            translation_key=_GROUP_LIGHTING,
+            name=None,
             via_device=_hub_device_identifier(server),
             configuration_url=f"http://{server.settings.host}",
         )
@@ -315,7 +325,8 @@ def ensure_scenarios_parent_device(server: AveWebServer, config_entry_id: str) -
             identifiers={_scenarios_parent_device_identifier(server)},
             manufacturer="AVE",
             model=_GROUP_MODELS[_GROUP_SCENARIOS],
-            name=_GROUP_NAMES[_GROUP_SCENARIOS],
+            translation_key=_GROUP_SCENARIOS,
+            name=None,
             via_device=_hub_device_identifier(server),
             configuration_url=f"http://{server.settings.host}",
         )
@@ -336,7 +347,8 @@ def ensure_covers_parent_device(server: AveWebServer, config_entry_id: str) -> N
             identifiers={_covers_parent_device_identifier(server)},
             manufacturer="AVE",
             model=_GROUP_MODELS[_GROUP_COVERS],
-            name=_GROUP_NAMES[_GROUP_COVERS],
+            translation_key=_GROUP_COVERS,
+            name=None,
             via_device=_hub_device_identifier(server),
             configuration_url=f"http://{server.settings.host}",
         )
@@ -359,7 +371,8 @@ def ensure_thermostats_parent_device(
             identifiers={_thermostats_parent_device_identifier(server)},
             manufacturer="AVE",
             model=_GROUP_MODELS[_GROUP_THERMOSTATS],
-            name=_GROUP_NAMES[_GROUP_THERMOSTATS],
+            translation_key=_GROUP_THERMOSTATS,
+            name=None,
             via_device=_hub_device_identifier(server),
             configuration_url=f"http://{server.settings.host}",
         )

--- a/custom_components/ave_dominaplus/device_info.py
+++ b/custom_components/ave_dominaplus/device_info.py
@@ -254,25 +254,10 @@ def build_endpoint_device_info(
     Device identifiers include the hub identifier to avoid collisions across hubs.
     """
     group_key = _endpoint_group_key(family, ave_device_id)
-    if group_key == _GROUP_ANTITHEFT_SENSORS:
-        endpoint_identifier = (
-            DOMAIN,
-            f"endpoint_{_hub_identifier(server)}_{group_key}_{ave_device_id}",
-        )
-        translation_key = group_key
-        device_name = None
-    elif group_key == _GROUP_ANTITHEFT_AREAS:
-        endpoint_identifier = (
-            DOMAIN,
-            f"endpoint_{_hub_identifier(server)}_{group_key}_{ave_device_id}",
-        )
-        translation_key = group_key
-        device_name = None
-    else:
-        endpoint_identifier = (
-            DOMAIN,
-            f"endpoint_{_hub_identifier(server)}_{group_key}",
-        )
+    endpoint_identifier = (
+        DOMAIN,
+        f"endpoint_{_hub_identifier(server)}_{group_key}",
+    )
 
     via_device = _hub_device_identifier(server)
     if family in (AVE_FAMILY_ONOFFLIGHTS, AVE_FAMILY_DIMMER):
@@ -289,7 +274,11 @@ def build_endpoint_device_info(
         via_device = _scenarios_parent_device_identifier(server)
 
     device_name: str | None = _endpoint_name(family, ave_device_id, ave_name)
-    translation_key: str | None = translation_key
+    translation_key: str | None = None
+
+    if group_key in (_GROUP_ANTITHEFT_SENSORS, _GROUP_ANTITHEFT_AREAS):
+        translation_key = group_key
+        device_name = None
 
     return DeviceInfo(
         identifiers={endpoint_identifier},
@@ -297,7 +286,6 @@ def build_endpoint_device_info(
         model=_endpoint_model(family),
         name=device_name,
         translation_key=translation_key,
-        translation_placeholders={"id": str(ave_device_id)},
         via_device=via_device,
         configuration_url=f"http://{server.settings.host}",
     )

--- a/custom_components/ave_dominaplus/light.py
+++ b/custom_components/ave_dominaplus/light.py
@@ -258,8 +258,13 @@ class DimmerLight(LightEntity):
             self._attr_supported_color_modes = {ColorMode.ONOFF}
             self._attr_color_mode = ColorMode.ONOFF
 
+        self._name = None
         if name is None:
-            self._name = self.build_name()
+            if self.family == AVE_FAMILY_ONOFFLIGHTS:
+                self._attr_translation_key = "light"
+            else:
+                self._attr_translation_key = "dimmer"
+            self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
         else:
             self._name = name
 
@@ -350,7 +355,7 @@ class DimmerLight(LightEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the entity."""
         return self._name
 

--- a/custom_components/ave_dominaplus/light.py
+++ b/custom_components/ave_dominaplus/light.py
@@ -258,15 +258,13 @@ class DimmerLight(LightEntity):
             self._attr_supported_color_modes = {ColorMode.ONOFF}
             self._attr_color_mode = ColorMode.ONOFF
 
-        self._name = None
         if name is None:
             if self.family == AVE_FAMILY_ONOFFLIGHTS:
                 self._attr_translation_key = "light"
             else:
                 self._attr_translation_key = "dimmer"
-            self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
         else:
-            self._name = name
+            self._attr_name = name
 
         self._attr_is_on = False
         if is_on is not None and is_on >= 0:
@@ -355,11 +353,6 @@ class DimmerLight(LightEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str | None:
-        """Return the name of the entity."""
-        return self._name
-
-    @property
     def available(self) -> bool:
         """Return if the backing webserver connection is available."""
         return self._webserver.connected
@@ -409,7 +402,7 @@ class DimmerLight(LightEntity):
         """Set the entity name."""
         if name is None:
             return
-        self._name = name
+        self._attr_name = name
         self._write_state_or_defer()
 
     def set_ave_name(self, name: str | None) -> None:

--- a/custom_components/ave_dominaplus/light.py
+++ b/custom_components/ave_dominaplus/light.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ws_commands
 from .const import AVE_FAMILY_DIMMER, AVE_FAMILY_ONOFFLIGHTS
@@ -27,7 +27,7 @@ PARALLEL_UPDATES = 1
 async def async_setup_entry(
     _hass: HomeAssistant | None,
     entry: ConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AVE dominaplus dimmer lights."""
     webserver: AveWebServer = entry.runtime_data

--- a/custom_components/ave_dominaplus/sensor.py
+++ b/custom_components/ave_dominaplus/sensor.py
@@ -249,7 +249,7 @@ class ThermostatOffset(SensorEntity):
     @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return the device class of the sensor."""
-        return SensorDeviceClass.TEMPERATURE_DELTA
+        return SensorDeviceClass.TEMPERATURE
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/ave_dominaplus/sensor.py
+++ b/custom_components/ave_dominaplus/sensor.py
@@ -237,7 +237,7 @@ class ThermostatOffset(SensorEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the sensor."""
         return self._name
 

--- a/custom_components/ave_dominaplus/sensor.py
+++ b/custom_components/ave_dominaplus/sensor.py
@@ -249,7 +249,7 @@ class ThermostatOffset(SensorEntity):
     @property
     def device_class(self) -> SensorDeviceClass | None:
         """Return the device class of the sensor."""
-        return SensorDeviceClass.TEMPERATURE
+        return SensorDeviceClass.TEMPERATURE_DELTA
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/ave_dominaplus/sensor.py
+++ b/custom_components/ave_dominaplus/sensor.py
@@ -1,4 +1,4 @@
-"""Binary sensor platform for AVE dominaplus integration."""
+"""Sensor platform for AVE dominaplus integration."""
 
 import logging
 from typing import Any
@@ -157,7 +157,7 @@ def check_name_changed(hass: HomeAssistant, unique_id: str) -> bool:
     entity_registry = er.async_get(hass)
 
     entry_id = entity_registry.async_get_entity_id(
-        "number", "ave_dominaplus", unique_id
+        "sensor", "ave_dominaplus", unique_id
     )
     if entry_id:
         entity_entry = entity_registry.async_get(entry_id)
@@ -209,11 +209,13 @@ class ThermostatOffset(SensorEntity):
 
         if name is None:
             if webserver.settings.get_entity_names:
-                self._name = f"Thermostat offset {self._ave_name or self.ave_device_id}"
+                self._attr_name = (
+                    f"Thermostat offset {self._ave_name or self.ave_device_id}"
+                )
             else:
-                self._name = self.build_name()
+                self._attr_name = self.build_name()
         else:
-            self._name = name
+            self._attr_name = name
 
         if value is not None:
             self.update_value(value, first_update=True)
@@ -235,11 +237,6 @@ class ThermostatOffset(SensorEntity):
     def unique_id(self) -> str:
         """Return the unique ID of the sensor."""
         return self._unique_id
-
-    @property
-    def name(self) -> str | None:
-        """Return the name of the sensor."""
-        return self._name
 
     @property
     def available(self) -> bool:
@@ -279,7 +276,7 @@ class ThermostatOffset(SensorEntity):
         """Set the name of the sensor."""
         if name is None:
             return
-        self._name = name
+        self._attr_name = name
         self._write_state_or_defer()
 
     def set_ave_name(self, name: str | None) -> None:

--- a/custom_components/ave_dominaplus/strings.json
+++ b/custom_components/ave_dominaplus/strings.json
@@ -124,6 +124,57 @@
     "binary_sensor": {
       "antitheft_sensor": {
         "name": "Antitheft Sensor {id}"
+      },
+      "scenario_running": {
+        "name": "Scenario {id} Running"
+      }
+    },
+    "button": {
+      "scenario_run": {
+        "name": "Scenario {id} Run"
+      }
+    },
+    "light": {
+      "light": {
+        "name": "Light {id}"
+      },
+      "dimmer": {
+        "name": "Dimmer {id}"
+      }
+    },
+    "cover": {
+      "shutter": {
+        "name": "Shutter {id}"
+      },
+      "blind": {
+        "name": "Blind {id}"
+      },
+      "window": {
+        "name": "Window {id}"
+      },
+      "cover": {
+        "name": "Cover {id}"
+      }
+    },
+    "climate": {
+      "thermostat": {
+        "name": "Thermostat {id}"
+      }
+    },
+    "switch": {
+      "light_switch": {
+        "name": "Light {id}"
+      },
+      "scenario_switch": {
+        "name": "Scenario {id}"
+      },
+      "generic_switch": {
+        "name": "Switch {family} {id}"
+      }
+    },
+    "sensor": {
+      "thermostat_offset": {
+        "name": "Thermostat Offset {id}"
       }
     }
   }

--- a/custom_components/ave_dominaplus/strings.json
+++ b/custom_components/ave_dominaplus/strings.json
@@ -131,7 +131,7 @@
     },
     "button": {
       "scenario_run": {
-        "name": "Run scenario {id}"
+        "name": "Scenario {id} Run"
       }
     },
     "light": {

--- a/custom_components/ave_dominaplus/strings.json
+++ b/custom_components/ave_dominaplus/strings.json
@@ -96,5 +96,28 @@
       "not_ave_webserver": "Discovered device is not an AVE webserver",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }
+  },
+  "device": {
+    "hub": {
+      "name": "Dominaplus Hub"
+    },
+    "lighting": {
+      "name": "Dominaplus Lighting"
+    },
+    "covers": {
+      "name": "Dominaplus Covers"
+    },
+    "thermostats": {
+      "name": "Dominaplus Thermostats"
+    },
+    "antitheft_sensors": {
+      "name": "Dominaplus Antitheft Sensors"
+    },
+    "antitheft_areas": {
+      "name": "Dominaplus Antitheft Areas"
+    },
+    "scenarios": {
+      "name": "Dominaplus Scenarios"
+    }
   }
 }

--- a/custom_components/ave_dominaplus/strings.json
+++ b/custom_components/ave_dominaplus/strings.json
@@ -111,10 +111,10 @@
       "name": "Dominaplus Thermostats"
     },
     "antitheft_sensors": {
-      "name": "Dominaplus Antitheft Sensors"
+      "name": "Dominaplus Antitheft Sensor {id}"
     },
     "antitheft_areas": {
-      "name": "Dominaplus Antitheft Areas"
+      "name": "Dominaplus Antitheft Area {id}"
     },
     "scenarios": {
       "name": "Dominaplus Scenarios"
@@ -123,7 +123,10 @@
   "entity": {
     "binary_sensor": {
       "antitheft_sensor": {
-        "name": "Antitheft Sensor {id}"
+        "name": "Sensor"
+      },
+      "antitheft_area": {
+        "name": "Area"
       },
       "scenario_running": {
         "name": "Scenario {id} Running"

--- a/custom_components/ave_dominaplus/strings.json
+++ b/custom_components/ave_dominaplus/strings.json
@@ -111,10 +111,10 @@
       "name": "Dominaplus Thermostats"
     },
     "antitheft_sensors": {
-      "name": "Dominaplus Antitheft Sensor {id}"
+      "name": "Dominaplus Antitheft Sensors"
     },
     "antitheft_areas": {
-      "name": "Dominaplus Antitheft Area {id}"
+      "name": "Dominaplus Antitheft Areas"
     },
     "scenarios": {
       "name": "Dominaplus Scenarios"
@@ -123,10 +123,10 @@
   "entity": {
     "binary_sensor": {
       "antitheft_sensor": {
-        "name": "Sensor"
+        "name": "Antitheft Sensor {id}"
       },
       "antitheft_area": {
-        "name": "Area"
+        "name": "Antitheft Area {id}"
       },
       "scenario_running": {
         "name": "Scenario {id} Running"

--- a/custom_components/ave_dominaplus/strings.json
+++ b/custom_components/ave_dominaplus/strings.json
@@ -123,18 +123,18 @@
   "entity": {
     "binary_sensor": {
       "antitheft_sensor": {
-        "name": "Antitheft Sensor {id}"
+        "name": "Antitheft Sensor"
       },
       "antitheft_area": {
-        "name": "Antitheft Area {id}"
+        "name": "Antitheft Area"
       },
       "scenario_running": {
-        "name": "Scenario {id} Running"
+        "name": "Running"
       }
     },
     "button": {
       "scenario_run": {
-        "name": "Scenario {id} Run"
+        "name": "Run"
       }
     },
     "light": {

--- a/custom_components/ave_dominaplus/strings.json
+++ b/custom_components/ave_dominaplus/strings.json
@@ -122,9 +122,6 @@
   },
   "entity": {
     "binary_sensor": {
-      "antitheft_area": {
-        "name": "Antitheft Area {id}"
-      },
       "antitheft_sensor": {
         "name": "Antitheft Sensor {id}"
       }

--- a/custom_components/ave_dominaplus/strings.json
+++ b/custom_components/ave_dominaplus/strings.json
@@ -131,7 +131,7 @@
     },
     "button": {
       "scenario_run": {
-        "name": "Scenario {id} Run"
+        "name": "Run scenario {id}"
       }
     },
     "light": {

--- a/custom_components/ave_dominaplus/strings.json
+++ b/custom_components/ave_dominaplus/strings.json
@@ -119,5 +119,15 @@
     "scenarios": {
       "name": "Dominaplus Scenarios"
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "antitheft_area": {
+        "name": "Antitheft Area {id}"
+      },
+      "antitheft_sensor": {
+        "name": "Antitheft Sensor {id}"
+      }
+    }
   }
 }

--- a/custom_components/ave_dominaplus/switch.py
+++ b/custom_components/ave_dominaplus/switch.py
@@ -214,8 +214,21 @@ class LightSwitch(SwitchEntity):
         if is_on is not None and is_on >= 0:
             self._attr_is_on = bool(is_on)  # Initialize the state
 
+        self._name = None
         if name is None:
-            self._name = self.build_name()
+            if self.family == AVE_FAMILY_ONOFFLIGHTS:
+                self._attr_translation_key = "light_switch"
+            elif self.family == AVE_FAMILY_SCENARIO:
+                self._attr_translation_key = "scenario_switch"
+            else:
+                self._attr_translation_key = "generic_switch"
+                self._attr_translation_placeholders = {
+                    "family": str(self.family),
+                    "id": str(self.ave_device_id),
+                }
+
+            if not hasattr(self, "_attr_translation_placeholders"):
+                self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
         else:
             self._name = name
 
@@ -254,7 +267,7 @@ class LightSwitch(SwitchEntity):
         return self._unique_id
 
     @property
-    def name(self) -> str:
+    def name(self) -> str | None:
         """Return the name of the sensor."""
         return self._name
 

--- a/custom_components/ave_dominaplus/switch.py
+++ b/custom_components/ave_dominaplus/switch.py
@@ -1,4 +1,4 @@
-"""Binary sensor platform for AVE dominaplus integration."""
+"""Switch platform for AVE dominaplus integration."""
 
 import logging
 from typing import Any
@@ -214,7 +214,6 @@ class LightSwitch(SwitchEntity):
         if is_on is not None and is_on >= 0:
             self._attr_is_on = bool(is_on)  # Initialize the state
 
-        self._name = None
         if name is None:
             if self.family == AVE_FAMILY_ONOFFLIGHTS:
                 self._attr_translation_key = "light_switch"
@@ -230,7 +229,7 @@ class LightSwitch(SwitchEntity):
             if not hasattr(self, "_attr_translation_placeholders"):
                 self._attr_translation_placeholders = {"id": str(self.ave_device_id)}
         else:
-            self._name = name
+            self._attr_name = name
 
     async def async_added_to_hass(self) -> None:
         """Handle entity added to Home Assistant."""
@@ -265,11 +264,6 @@ class LightSwitch(SwitchEntity):
     def unique_id(self) -> str:
         """Return the unique ID of the sensor."""
         return self._unique_id
-
-    @property
-    def name(self) -> str | None:
-        """Return the name of the sensor."""
-        return self._name
 
     @property
     def available(self) -> bool:
@@ -310,7 +304,7 @@ class LightSwitch(SwitchEntity):
         """Set the name of the sensor."""
         if name is None:
             return
-        self._name = name
+        self._attr_name = name
         self._write_state_or_defer()
 
     def set_ave_name(self, name: str | None) -> None:

--- a/custom_components/ave_dominaplus/switch.py
+++ b/custom_components/ave_dominaplus/switch.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import ws_commands
 from .const import AVE_FAMILY_ONOFFLIGHTS, AVE_FAMILY_SCENARIO
@@ -26,7 +26,7 @@ PARALLEL_UPDATES = 1
 async def async_setup_entry(
     _hass: HomeAssistant | None,
     entry: ConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AVE dominaplus binary sensors.
 

--- a/custom_components/ave_dominaplus/translations/en.json
+++ b/custom_components/ave_dominaplus/translations/en.json
@@ -105,10 +105,10 @@
       "name": "Dominaplus Thermostats"
     },
     "antitheft_sensors": {
-      "name": "Dominaplus Antitheft Sensors"
+      "name": "Dominaplus Antitheft Sensor {id}"
     },
     "antitheft_areas": {
-      "name": "Dominaplus Antitheft Areas"
+      "name": "Dominaplus Antitheft Area {id}"
     },
     "scenarios": {
       "name": "Dominaplus Scenarios"
@@ -117,7 +117,10 @@
   "entity": {
     "binary_sensor": {
       "antitheft_sensor": {
-        "name": "Antitheft Sensor {id}"
+        "name": "Sensor"
+      },
+      "antitheft_area": {
+        "name": "Area"
       },
       "scenario_running": {
         "name": "Scenario {id} Running"

--- a/custom_components/ave_dominaplus/translations/en.json
+++ b/custom_components/ave_dominaplus/translations/en.json
@@ -105,10 +105,10 @@
       "name": "Dominaplus Thermostats"
     },
     "antitheft_sensors": {
-      "name": "Dominaplus Antitheft Sensor {id}"
+      "name": "Dominaplus Antitheft Sensors"
     },
     "antitheft_areas": {
-      "name": "Dominaplus Antitheft Area {id}"
+      "name": "Dominaplus Antitheft Areas"
     },
     "scenarios": {
       "name": "Dominaplus Scenarios"
@@ -117,10 +117,10 @@
   "entity": {
     "binary_sensor": {
       "antitheft_sensor": {
-        "name": "Sensor"
+        "name": "Antitheft Sensor {id}"
       },
       "antitheft_area": {
-        "name": "Area"
+        "name": "Antitheft Area {id}"
       },
       "scenario_running": {
         "name": "Scenario {id} Running"

--- a/custom_components/ave_dominaplus/translations/en.json
+++ b/custom_components/ave_dominaplus/translations/en.json
@@ -117,18 +117,18 @@
   "entity": {
     "binary_sensor": {
       "antitheft_sensor": {
-        "name": "Antitheft Sensor {id}"
+        "name": "Antitheft Sensor"
       },
       "antitheft_area": {
-        "name": "Antitheft Area {id}"
+        "name": "Antitheft Area"
       },
       "scenario_running": {
-        "name": "Scenario {id} Running"
+        "name": "Running"
       }
     },
     "button": {
       "scenario_run": {
-        "name": "Scenario {id} Run"
+        "name": "Run"
       }
     },
     "light": {

--- a/custom_components/ave_dominaplus/translations/en.json
+++ b/custom_components/ave_dominaplus/translations/en.json
@@ -116,9 +116,6 @@
   },
   "entity": {
     "binary_sensor": {
-      "antitheft_area": {
-        "name": "Antitheft Area {id}"
-      },
       "antitheft_sensor": {
         "name": "Antitheft Sensor {id}"
       }

--- a/custom_components/ave_dominaplus/translations/en.json
+++ b/custom_components/ave_dominaplus/translations/en.json
@@ -118,6 +118,57 @@
     "binary_sensor": {
       "antitheft_sensor": {
         "name": "Antitheft Sensor {id}"
+      },
+      "scenario_running": {
+        "name": "Scenario {id} Running"
+      }
+    },
+    "button": {
+      "scenario_run": {
+        "name": "Scenario {id} Run"
+      }
+    },
+    "light": {
+      "light": {
+        "name": "Light {id}"
+      },
+      "dimmer": {
+        "name": "Dimmer {id}"
+      }
+    },
+    "cover": {
+      "shutter": {
+        "name": "Shutter {id}"
+      },
+      "blind": {
+        "name": "Blind {id}"
+      },
+      "window": {
+        "name": "Window {id}"
+      },
+      "cover": {
+        "name": "Cover {id}"
+      }
+    },
+    "climate": {
+      "thermostat": {
+        "name": "Thermostat {id}"
+      }
+    },
+    "switch": {
+      "light_switch": {
+        "name": "Light {id}"
+      },
+      "scenario_switch": {
+        "name": "Scenario {id}"
+      },
+      "generic_switch": {
+        "name": "Switch {family} {id}"
+      }
+    },
+    "sensor": {
+      "thermostat_offset": {
+        "name": "Thermostat Offset {id}"
       }
     }
   }

--- a/custom_components/ave_dominaplus/translations/en.json
+++ b/custom_components/ave_dominaplus/translations/en.json
@@ -113,5 +113,15 @@
     "scenarios": {
       "name": "Dominaplus Scenarios"
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "antitheft_area": {
+        "name": "Antitheft Area {id}"
+      },
+      "antitheft_sensor": {
+        "name": "Antitheft Sensor {id}"
+      }
+    }
   }
 }

--- a/custom_components/ave_dominaplus/translations/en.json
+++ b/custom_components/ave_dominaplus/translations/en.json
@@ -125,7 +125,7 @@
     },
     "button": {
       "scenario_run": {
-        "name": "Scenario {id} Run"
+        "name": "Run scenario {id}"
       }
     },
     "light": {

--- a/custom_components/ave_dominaplus/translations/en.json
+++ b/custom_components/ave_dominaplus/translations/en.json
@@ -90,5 +90,28 @@
       "not_ave_webserver": "Discovered device is not an AVE webserver",
       "unknown": "Unknown error"
     }
+  },
+  "device": {
+    "hub": {
+      "name": "Dominaplus Hub"
+    },
+    "lighting": {
+      "name": "Dominaplus Lighting"
+    },
+    "covers": {
+      "name": "Dominaplus Covers"
+    },
+    "thermostats": {
+      "name": "Dominaplus Thermostats"
+    },
+    "antitheft_sensors": {
+      "name": "Dominaplus Antitheft Sensors"
+    },
+    "antitheft_areas": {
+      "name": "Dominaplus Antitheft Areas"
+    },
+    "scenarios": {
+      "name": "Dominaplus Scenarios"
+    }
   }
 }

--- a/custom_components/ave_dominaplus/translations/en.json
+++ b/custom_components/ave_dominaplus/translations/en.json
@@ -125,7 +125,7 @@
     },
     "button": {
       "scenario_run": {
-        "name": "Run scenario {id}"
+        "name": "Scenario {id} Run"
       }
     },
     "light": {

--- a/custom_components/ave_dominaplus/translations/it.json
+++ b/custom_components/ave_dominaplus/translations/it.json
@@ -105,10 +105,10 @@
       "name": "Dominaplus Termoregolazione"
     },
     "antitheft_sensors": {
-      "name": "Sensore Antintrusione Dominaplus {id}"
+      "name": "Dominaplus Sensori Antintrusione"
     },
     "antitheft_areas": {
-      "name": "Area Antintrusione Dominaplus {id}"
+      "name": "Dominaplus Aree Antintrusione"
     },
     "scenarios": {
       "name": "Dominaplus Scenari"
@@ -117,10 +117,10 @@
   "entity": {
     "binary_sensor": {
       "antitheft_sensor": {
-        "name": "Sensore"
+        "name": "Sensore Antintrusione {id}"
       },
       "antitheft_area": {
-        "name": "Area"
+        "name": "Area Antintrusione {id}"
       },
       "scenario_running": {
         "name": "Esecuzione Scenario {id}"

--- a/custom_components/ave_dominaplus/translations/it.json
+++ b/custom_components/ave_dominaplus/translations/it.json
@@ -116,9 +116,6 @@
   },
   "entity": {
     "binary_sensor": {
-      "antitheft_area": {
-        "name": "Area Antintrusione {id}"
-      },
       "antitheft_sensor": {
         "name": "Sensore Antintrusione {id}"
       }

--- a/custom_components/ave_dominaplus/translations/it.json
+++ b/custom_components/ave_dominaplus/translations/it.json
@@ -120,12 +120,12 @@
         "name": "Sensore Antintrusione {id}"
       },
       "scenario_running": {
-        "name": "Scenario {id} in corso"
+        "name": "Esecuzione Scenario {id}"
       }
     },
     "button": {
       "scenario_run": {
-        "name": "Esegui scenario {id}"
+        "name": "Esegui Scenario {id}"
       }
     },
     "light": {

--- a/custom_components/ave_dominaplus/translations/it.json
+++ b/custom_components/ave_dominaplus/translations/it.json
@@ -118,6 +118,57 @@
     "binary_sensor": {
       "antitheft_sensor": {
         "name": "Sensore Antintrusione {id}"
+      },
+      "scenario_running": {
+        "name": "Esecuzione Scenario {id}"
+      }
+    },
+    "button": {
+      "scenario_run": {
+        "name": "Esegui Scenario {id}"
+      }
+    },
+    "light": {
+      "light": {
+        "name": "Luce {id}"
+      },
+      "dimmer": {
+        "name": "Dimmer {id}"
+      }
+    },
+    "cover": {
+      "shutter": {
+        "name": "Tapparella {id}"
+      },
+      "blind": {
+        "name": "Veneziana {id}"
+      },
+      "window": {
+        "name": "Finestra {id}"
+      },
+      "cover": {
+        "name": "Copertura {id}"
+      }
+    },
+    "climate": {
+      "thermostat": {
+        "name": "Termostato {id}"
+      }
+    },
+    "switch": {
+      "light_switch": {
+        "name": "Luce {id}"
+      },
+      "scenario_switch": {
+        "name": "Scenario {id}"
+      },
+      "generic_switch": {
+        "name": "Interruttore {family} {id}"
+      }
+    },
+    "sensor": {
+      "thermostat_offset": {
+        "name": "Offset Termostato {id}"
       }
     }
   }

--- a/custom_components/ave_dominaplus/translations/it.json
+++ b/custom_components/ave_dominaplus/translations/it.json
@@ -90,5 +90,28 @@
       "not_ave_webserver": "Il dispositivo scoperto non è un webserver AVE",
       "unknown": "Errore sconosciuto"
     }
+  },
+  "device": {
+    "hub": {
+      "name": "Hub Dominaplus"
+    },
+    "lighting": {
+      "name": "Luci Dominaplus"
+    },
+    "covers": {
+      "name": "Tapparelle Dominaplus"
+    },
+    "thermostats": {
+      "name": "Termostati Dominaplus"
+    },
+    "antitheft_sensors": {
+      "name": "Sensori Antifurto Dominaplus"
+    },
+    "antitheft_areas": {
+      "name": "Aree Antifurto Dominaplus"
+    },
+    "scenarios": {
+      "name": "Scenari Dominaplus"
+    }
   }
 }

--- a/custom_components/ave_dominaplus/translations/it.json
+++ b/custom_components/ave_dominaplus/translations/it.json
@@ -120,12 +120,12 @@
         "name": "Sensore Antintrusione {id}"
       },
       "scenario_running": {
-        "name": "Esecuzione Scenario {id}"
+        "name": "Scenario {id} in corso"
       }
     },
     "button": {
       "scenario_run": {
-        "name": "Esegui Scenario {id}"
+        "name": "Esegui scenario {id}"
       }
     },
     "light": {

--- a/custom_components/ave_dominaplus/translations/it.json
+++ b/custom_components/ave_dominaplus/translations/it.json
@@ -114,7 +114,7 @@
       "name": "Dominaplus Scenari"
     }
   },
-    "entity": {
+  "entity": {
     "binary_sensor": {
       "antitheft_sensor": {
         "name": "Sensore Antintrusione {id}"

--- a/custom_components/ave_dominaplus/translations/it.json
+++ b/custom_components/ave_dominaplus/translations/it.json
@@ -113,5 +113,15 @@
     "scenarios": {
       "name": "Dominaplus Scenari"
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "antitheft_area": {
+        "name": "Area Antintrusione {id}"
+      },
+      "antitheft_sensor": {
+        "name": "Sensore Antintrusione {id}"
+      }
+    }
   }
 }

--- a/custom_components/ave_dominaplus/translations/it.json
+++ b/custom_components/ave_dominaplus/translations/it.json
@@ -117,18 +117,18 @@
   "entity": {
     "binary_sensor": {
       "antitheft_sensor": {
-        "name": "Sensore Antintrusione {id}"
+        "name": "Sensore Antintrusione"
       },
       "antitheft_area": {
-        "name": "Area Antintrusione {id}"
+        "name": "Area Antintrusione"
       },
       "scenario_running": {
-        "name": "Esecuzione Scenario {id}"
+        "name": "In Esecuzione"
       }
     },
     "button": {
       "scenario_run": {
-        "name": "Esegui Scenario {id}"
+        "name": "Esegui"
       }
     },
     "light": {

--- a/custom_components/ave_dominaplus/translations/it.json
+++ b/custom_components/ave_dominaplus/translations/it.json
@@ -105,10 +105,10 @@
       "name": "Dominaplus Termoregolazione"
     },
     "antitheft_sensors": {
-      "name": "Dominaplus Sensori Antintrusione"
+      "name": "Sensore Antintrusione Dominaplus {id}"
     },
     "antitheft_areas": {
-      "name": "Dominaplus Aree Antintrusione"
+      "name": "Area Antintrusione Dominaplus {id}"
     },
     "scenarios": {
       "name": "Dominaplus Scenari"
@@ -117,7 +117,10 @@
   "entity": {
     "binary_sensor": {
       "antitheft_sensor": {
-        "name": "Sensore Antintrusione {id}"
+        "name": "Sensore"
+      },
+      "antitheft_area": {
+        "name": "Area"
       },
       "scenario_running": {
         "name": "Esecuzione Scenario {id}"

--- a/custom_components/ave_dominaplus/translations/it.json
+++ b/custom_components/ave_dominaplus/translations/it.json
@@ -93,25 +93,25 @@
   },
   "device": {
     "hub": {
-      "name": "Hub Dominaplus"
+      "name": "Dominaplus Hub"
     },
     "lighting": {
-      "name": "Luci Dominaplus"
+      "name": "Dominaplus Luci"
     },
     "covers": {
-      "name": "Tapparelle Dominaplus"
+      "name": "Dominaplus Serramenti"
     },
     "thermostats": {
-      "name": "Termostati Dominaplus"
+      "name": "Dominaplus Termoregolazione"
     },
     "antitheft_sensors": {
-      "name": "Sensori Antifurto Dominaplus"
+      "name": "Dominaplus Sensori Antintrusione"
     },
     "antitheft_areas": {
-      "name": "Aree Antifurto Dominaplus"
+      "name": "Dominaplus Aree Antintrusione"
     },
     "scenarios": {
-      "name": "Scenari Dominaplus"
+      "name": "Dominaplus Scenari"
     }
   }
 }

--- a/custom_components/ave_dominaplus/translations/it.json
+++ b/custom_components/ave_dominaplus/translations/it.json
@@ -114,7 +114,7 @@
       "name": "Dominaplus Scenari"
     }
   },
-  "entity": {
+    "entity": {
     "binary_sensor": {
       "antitheft_sensor": {
         "name": "Sensore Antintrusione {id}"

--- a/tests/test_binary_sensor_branch_sweep.py
+++ b/tests/test_binary_sensor_branch_sweep.py
@@ -467,7 +467,8 @@ async def test_scenario_running_sensor_lifecycle_and_state_branches(hass) -> Non
     )
     sensor.async_write_ha_state = Mock()
 
-    assert sensor.name == "Scenario 12 Running"
+    assert sensor.translation_key == "scenario_running"
+    assert sensor.translation_placeholders == {"id": "12"}
     assert sensor.unique_id == "uid-scenario"
     assert sensor.available is True
     assert sensor.is_on is False

--- a/tests/test_binary_sensor_update_flow.py
+++ b/tests/test_binary_sensor_update_flow.py
@@ -52,7 +52,8 @@ def test_update_binary_sensor_creates_motion_sensor(hass: HomeAssistant) -> None
     unique_id = set_sensor_uid(AVE_FAMILY_MOTION_SENSOR, 8)
     assert unique_id in server.binary_sensors
     created = server.binary_sensors[unique_id]
-    assert created.name == "Antitheft Sensor 8"
+    assert created.translation_key == "antitheft_sensor"
+    assert getattr(created, "translation_placeholders", {}) == {"id": "8"}
     server.async_add_bs_entities.assert_called_once()
 
 

--- a/tests/test_button_branch_sweep.py
+++ b/tests/test_button_branch_sweep.py
@@ -258,7 +258,8 @@ def test_scenario_button_properties_and_state_write_paths(hass) -> None:
     button.async_write_ha_state = Mock()
 
     assert button.unique_id == "uid"
-    assert button.name == "Scenario 7 Run"
+    assert button.translation_key == "scenario_run"
+    assert button.translation_placeholders == {"id": "7"}
     assert button.available is True
     assert button.extra_state_attributes == {
         "AVE_family": AVE_FAMILY_SCENARIO,

--- a/tests/test_climate_branch_sweep.py
+++ b/tests/test_climate_branch_sweep.py
@@ -204,7 +204,8 @@ async def test_thermostat_entity_edge_paths_and_lifecycle(hass) -> None:
     thermostat.async_write_ha_state = Mock()
 
     assert thermostat.unique_id == "uid"
-    assert thermostat.name == "Thermostat 9"
+    assert thermostat.translation_key == "thermostat"
+    
     assert thermostat.available is False
 
     with (

--- a/tests/test_climate_branch_sweep.py
+++ b/tests/test_climate_branch_sweep.py
@@ -205,7 +205,7 @@ async def test_thermostat_entity_edge_paths_and_lifecycle(hass) -> None:
 
     assert thermostat.unique_id == "uid"
     assert thermostat.translation_key == "thermostat"
-    
+
     assert thermostat.available is False
 
     with (

--- a/tests/test_climate_entity_behavior.py
+++ b/tests/test_climate_entity_behavior.py
@@ -37,7 +37,8 @@ def _new_server(hass: HomeAssistant) -> AveWebServer:
         "fetch_thermostats": True,
         "on_off_lights_as_switch": True,
     }
-    return AveWebServer(settings, hass)
+    server = AveWebServer(settings, hass)
+    return server  # noqa: RET504
 
 
 def _props(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,7 +16,10 @@ from custom_components.ave_dominaplus.config_flow import (
 )
 from custom_components.ave_dominaplus.const import DOMAIN
 from homeassistant import config_entries, data_entry_flow
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
+try:
+    from homeassistant.components.zeroconf import ZeroconfServiceInfo
+except ImportError:
+    from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -18,7 +18,7 @@ from custom_components.ave_dominaplus.const import DOMAIN
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+from homeassistant.components.zeroconf import ZeroconfServiceInfo
 
 MOCK_USER_INPUT: dict[str, object] = {
     CONF_IP_ADDRESS: "192.168.1.10",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,9 +16,9 @@ from custom_components.ave_dominaplus.config_flow import (
 )
 from custom_components.ave_dominaplus.const import DOMAIN
 from homeassistant import config_entries, data_entry_flow
+from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
 
 MOCK_USER_INPUT: dict[str, object] = {
     CONF_IP_ADDRESS: "192.168.1.10",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,6 +16,7 @@ from custom_components.ave_dominaplus.config_flow import (
 )
 from custom_components.ave_dominaplus.const import DOMAIN
 from homeassistant import config_entries, data_entry_flow
+
 try:
     from homeassistant.components.zeroconf import ZeroconfServiceInfo
 except ImportError:

--- a/tests/test_cover_branch_sweep.py
+++ b/tests/test_cover_branch_sweep.py
@@ -383,7 +383,8 @@ async def test_cover_entity_methods_and_properties_cover_remaining_paths(hass) -
     cover = AveCover("uid", AVE_FAMILY_SHUTTER_ROLLING, 5, 1, server)
     cover.async_write_ha_state = Mock()
 
-    assert cover.name == "Shutter 5"
+    assert cover.translation_key == "shutter"
+    assert cover.translation_placeholders == {"id": "5"}
     assert cover.available is True
     assert cover.is_closed is False
     assert cover.is_opening is False
@@ -424,7 +425,8 @@ def test_cover_mutators_and_write_defer_paths(hass) -> None:
     cover = AveCover("uid", AVE_FAMILY_SHUTTER_SLIDING, 6, None, server)
     cover.async_write_ha_state = Mock()
 
-    assert cover.name == "Blind 6"
+    assert cover.translation_key == "blind"
+    assert cover.translation_placeholders == {"id": "6"}
     assert cover.extra_state_attributes["AVE address_hex"] == ""
 
     cover.update_state(None)
@@ -455,7 +457,8 @@ def test_cover_build_name_variants(hass) -> None:
     hung = AveCover("u3", AVE_FAMILY_SHUTTER_HUNG, 3, None, server)
     unknown = AveCover("u4", 999, 4, None, server)
 
-    assert rolling.name == "Shutter 1"
-    assert sliding.name == "Blind 2"
-    assert hung.name == "Window 3"
-    assert unknown.name == "Cover 4"
+    assert rolling.translation_key == "shutter"
+    assert rolling.name is None
+    assert sliding.translation_key == "blind"
+    assert hung.translation_key == "window"
+    assert unknown.translation_key == "cover"

--- a/tests/test_device_info.py
+++ b/tests/test_device_info.py
@@ -136,7 +136,7 @@ def test_ensure_lighting_parent_device_registers_under_hub(hass) -> None:
         manufacturer="AVE",
         model="AVE dominaplus lighting",
         translation_key="lighting",
-            name=None,
+        name=None,
         via_device=(DOMAIN, "hub_aa:bb:cc:dd:ee:ff"),
         configuration_url="http://10.0.0.99",
     )
@@ -157,7 +157,7 @@ def test_ensure_scenarios_parent_device_registers_under_hub(hass) -> None:
         manufacturer="AVE",
         model="AVE dominaplus scenarios",
         translation_key="scenarios",
-            name=None,
+        name=None,
         via_device=(DOMAIN, "hub_aa:bb:cc:dd:ee:ff"),
         configuration_url="http://10.0.0.99",
     )
@@ -178,7 +178,7 @@ def test_ensure_covers_parent_device_registers_under_hub(hass) -> None:
         manufacturer="AVE",
         model="AVE dominaplus covers",
         translation_key="covers",
-            name=None,
+        name=None,
         via_device=(DOMAIN, "hub_aa:bb:cc:dd:ee:ff"),
         configuration_url="http://10.0.0.99",
     )
@@ -199,7 +199,7 @@ def test_ensure_thermostats_parent_device_registers_under_hub(hass) -> None:
         manufacturer="AVE",
         model="AVE dominaplus thermostats",
         translation_key="thermostats",
-            name=None,
+        name=None,
         via_device=(DOMAIN, "hub_aa:bb:cc:dd:ee:ff"),
         configuration_url="http://10.0.0.99",
     )

--- a/tests/test_device_info.py
+++ b/tests/test_device_info.py
@@ -82,7 +82,7 @@ def test_device_info_falls_back_to_host() -> None:
     assert info.get("identifiers") == {(DOMAIN, "hub_10.0.0.99")}
     assert info.get("manufacturer") == "AVE"
     assert info.get("model") == "AVE dominaplus webserver"
-    assert info.get("name") == "Dominaplus Hub"
+    assert info.get("translation_key") == "hub"
     assert info.get("configuration_url") == "http://10.0.0.99"
 
 
@@ -135,7 +135,8 @@ def test_ensure_lighting_parent_device_registers_under_hub(hass) -> None:
         identifiers={(DOMAIN, "endpoint_aa:bb:cc:dd:ee:ff_lighting")},
         manufacturer="AVE",
         model="AVE dominaplus lighting",
-        name="Dominaplus Lighting",
+        translation_key="lighting",
+            name=None,
         via_device=(DOMAIN, "hub_aa:bb:cc:dd:ee:ff"),
         configuration_url="http://10.0.0.99",
     )
@@ -155,7 +156,8 @@ def test_ensure_scenarios_parent_device_registers_under_hub(hass) -> None:
         identifiers={(DOMAIN, "endpoint_aa:bb:cc:dd:ee:ff_scenarios")},
         manufacturer="AVE",
         model="AVE dominaplus scenarios",
-        name="Dominaplus Scenarios",
+        translation_key="scenarios",
+            name=None,
         via_device=(DOMAIN, "hub_aa:bb:cc:dd:ee:ff"),
         configuration_url="http://10.0.0.99",
     )
@@ -175,7 +177,8 @@ def test_ensure_covers_parent_device_registers_under_hub(hass) -> None:
         identifiers={(DOMAIN, "endpoint_aa:bb:cc:dd:ee:ff_covers")},
         manufacturer="AVE",
         model="AVE dominaplus covers",
-        name="Dominaplus Covers",
+        translation_key="covers",
+            name=None,
         via_device=(DOMAIN, "hub_aa:bb:cc:dd:ee:ff"),
         configuration_url="http://10.0.0.99",
     )
@@ -195,7 +198,8 @@ def test_ensure_thermostats_parent_device_registers_under_hub(hass) -> None:
         identifiers={(DOMAIN, "endpoint_aa:bb:cc:dd:ee:ff_thermostats")},
         manufacturer="AVE",
         model="AVE dominaplus thermostats",
-        name="Dominaplus Thermostats",
+        translation_key="thermostats",
+            name=None,
         via_device=(DOMAIN, "hub_aa:bb:cc:dd:ee:ff"),
         configuration_url="http://10.0.0.99",
     )
@@ -350,7 +354,7 @@ def test_endpoint_motion_sensors_are_grouped() -> None:
     )
 
     assert info.get("identifiers") == {(DOMAIN, "endpoint_entry-123_antitheft_sensors")}
-    assert info.get("name") == "Dominaplus Antitheft Sensors"
+    assert info.get("translation_key") == "antitheft_sensors"
 
 
 def test_endpoint_scenario_name_falls_back_to_device_id() -> None:

--- a/tests/test_light_update_flow.py
+++ b/tests/test_light_update_flow.py
@@ -187,7 +187,8 @@ def test_update_light_uses_default_name_when_entity_names_disabled(
 
     unique_id = build_uid(server.mac_address, AVE_FAMILY_DIMMER, 4, 12)
     created = server.lights[unique_id]
-    assert created.name == "Dimmer 4"
+    assert created.translation_key == "dimmer"
+    assert created.name is None
 
 
 def test_light_set_ave_name_updates_device_info_name(hass: HomeAssistant) -> None:

--- a/tests/test_sensor_branch_sweep.py
+++ b/tests/test_sensor_branch_sweep.py
@@ -169,7 +169,7 @@ def test_sensor_properties_mutators_and_write_paths(hass) -> None:
     entity.async_write_ha_state = Mock()
 
     assert entity.available is True
-    assert entity.device_class == SensorDeviceClass.TEMPERATURE_DELTA
+    assert entity.device_class == SensorDeviceClass.TEMPERATURE
     assert entity.extra_state_attributes["AVE webserver MAC"] == "aa:bb:cc:dd:ee:ff"
 
     entity.update_value(None)

--- a/tests/test_switch_update_flow.py
+++ b/tests/test_switch_update_flow.py
@@ -173,7 +173,8 @@ def test_switch_build_name_covers_scenario_family(hass: HomeAssistant) -> None:
     server = _new_server(hass)
     switch = LightSwitch("uid", AVE_FAMILY_SCENARIO, 33, 0, server)
 
-    assert switch.name == "Scenario 33"
+    assert switch.translation_key == "scenario_switch"
+    assert switch.translation_placeholders == {"id": "33"}
 
 
 def test_switch_set_ave_name_updates_device_info_name(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Updates entity naming to use `_attr_translation_key` instead of manually setting `_attr_name`. Introduces proper HA container translations for devices.

**Depends on #26 (Test Lint Fixes)** - this branch is based on top of `ladiavola:fix-test-lint` so it expects the lint PR to merge first.